### PR TITLE
CI improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
     secure: RgfMtQ0AdNtC/Jr6cnC/8OZJBfj8VrRXa7yxcHdRrm0Gkch+6q2lUVXDUbz0BxTH
   COVERALLS_SERVICE_NAME: appveyor
   COVERALLS_SERVICE_JOB_ID: '%APPVEYOR_JOB_ID%'
-build:
-  project: $(PROJECT).sln
-  publish_wap: true
-  verbosity: minimal
 cache:
   - packages -> **\packages.config
 notifications:
@@ -28,6 +24,11 @@ install:
 
 before_build:
   - appveyor-retry nuget restore -DisableParallelProcessing
+build:
+  project: $(PROJECT).sln
+  publish_wap: true
+  verbosity: minimal
+after_build:
   - cd %PROJECT%
   - npm install
   - npm run build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
   COVERALLS_SERVICE_JOB_ID: '%APPVEYOR_JOB_ID%'
 cache:
   - packages -> **\packages.config
+  - $(PROJECT)\node_modules -> $(PROJECT)\package.json
 notifications:
   - provider: Slack
     incoming_webhook:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,15 +25,14 @@ install:
 
 before_build:
   - appveyor-retry nuget restore -DisableParallelProcessing
-build:
-  project: $(PROJECT).sln
-  publish_wap: true
-  verbosity: minimal
-after_build:
   - cd %PROJECT%
   - npm install
   - npm run build
   - cd ..
+build:
+  project: $(PROJECT).sln
+  publish_wap: true
+  verbosity: minimal
 
 test_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,8 +48,6 @@ test_script:
         Write-Warning $msg
       } else {
           $env:PATH = $env:PATH + ';' + (Resolve-Path ./node_modules/.bin).Path
-          npm run build
-          if ($LASTEXITCODE -ne 0) { throw "Execution failed with exit code $LASTEXITCODE" }
           electron-mocha --opts tests/mocha-appveyor.opts
           if ($LASTEXITCODE -ne 0) { throw "Execution failed with exit code $LASTEXITCODE" }
           remap-istanbul -i ./coverage/coverage-final.json -o ./coverage/coverage-final.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ build:
   verbosity: minimal
 cache:
   - packages -> **\packages.config
-  - '%APPDATA%\npm-cache'
 notifications:
   - provider: Slack
     incoming_webhook:


### PR DESCRIPTION
* The global npm cache is no longer cached. This is probably only useful with multiple projects.
* Enable caching of `node_modules`.
* Don't build again during test phase.